### PR TITLE
Remove demo link

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -7,7 +7,6 @@ author:
   email: e.delanoy@adweb-services
   url: www.adweb-services.com
 homepage: 
-demo: http://www.demo.adweb-services.com/gravi-k/
 keywords: Gravi-K, theme, customization, modern, fast, responsive, html5, css3, framework Knacss,
 bugs: 
 license: MIT


### PR DESCRIPTION
The demo site domain expired, can you accept the PR and make a new release? Or we link to that in the Grav site otherwise.